### PR TITLE
Change pypi workflow to trigger on release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,7 +20,7 @@ name: Upload Nourish to PyPI
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   deploy:
@@ -52,4 +52,4 @@ jobs:
         env:
           room-id: ${{ secrets.GITTER_ROOM_ID }}
           token: ${{ secrets.GITTER_TOKEN }}
-          text: 'Version $GITHUB_REF published to PyPI --> https://pypi.org/project/nourish/'
+          text: 'New version published to PyPI --> https://pypi.org/project/nourish/'

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -206,11 +206,12 @@ To make a new release:
 
 - Tag the commit following `PEP 0440 <https://www.python.org/dev/peps/pep-0440>`__, e.g. ``git tag -a v0.1a1 -m "First Alpha Release"``.
 - Push the tag, e.g. ``git push origin v0.1a1``.
+- On the `GitHub Releases <https://github.com/edwardleardi/nourish/releases>`__ page, convert the tag into a release by adding a title, description, and marking whether or not it is a pre-release.
 
 To publish to PyPI:
 
-- Once a release is pushed, :file:`.github/workflows/publish-to-pypi.yml` will automatically upload it to PyPI.
-- However to manually upload, run ``python setup.py sdist bdist_wheel`` then ``twine upload -r pypi dist/nourish-x.x*``.
+- When a full release is created, :file:`.github/workflows/publish-to-pypi.yml` will automatically upload it to PyPI.
+- However to manually upload a release, run ``python setup.py sdist bdist_wheel`` then ``twine upload -r pypi dist/nourish-x.x*``.
 
 Pull Request & Issues
 ---------------------


### PR DESCRIPTION
Signed-off-by: Edward Leardi <edleardi@gmail.com>

---

## Pull Request Checklist

<details open>

<summary>Toggle</summary>
<br/>

- Does this pull request close an issue? We encourage you to open an issue first if this pull request (PR) is not a minor change.
  - [x] No
    - [x] The change in this pull request is minor.
  - [ ] Yes
    - Close #{issue_number}

- For the following questions, only check the boxes that are applicable.
  - [x] Ensure that the pull request text above the horizontal line is descriptive.
  - [x] Add/update relevant tests.
  - [x] Add/update relevant documents.

- Do you have triage permission of this repository?
  - [ ] No
    - You are good.
  - [x] Yes
    - Does this pull request close an issue?
      - [ ] No, this pull request also acts as an issue by itself.
        - [ ] Assign yourself.
        - [ ] Label this pull request.
        - [ ] Put a release.
        - [ ] Put this pull request under "In Progress" or "Under Review" pipeline on ZenHub.
        - [ ] Put this pull request under the appropriate epic on ZenHub.
        - [ ] Put an estimate on ZenHub.
        - [ ] Add dependency relationship with other issues/pull requests on ZenHub.
      - [ ] Yes, this pull request addresses an issue and does not act as an issue.
        - [ ] Connect this pull request to the underlying issue on ZenHub.
        - [ ] DON'T:
          - DON'T assign yourself or anyone else.
          - DON'T label.
          - DON'T put a milestone.
          - DON'T put this pull request under any epic on ZenHub.
          - DON'T put an estimate on ZenHub.
    - [ ] When the pull request is ready, request review.
</details>


## Developer's Certificate of Origin (DCO)

<details open>

<summary>Toggle</summary>
<br/>

```
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
